### PR TITLE
Using uint8 for 16-bit output formats.

### DIFF
--- a/ximea.pyx
+++ b/ximea.pyx
@@ -194,7 +194,7 @@ cdef class Xi_Camera:
         if self._xi_image.frm == xi.XI_MONO8 or self._xi_image.frm == xi.XI_RAW8:
             img_array = np.asarray(<np.uint8_t[:self._xi_image.bp_size]> self._xi_image.bp).reshape((self._xi_image.height,self._xi_image.width))
         elif self._xi_image.frm == xi.XI_MONO16 or self._xi_image.frm == xi.XI_RAW16:
-            img_array = np.asarray(<np.uint16_t[:self._xi_image.bp_size]> self._xi_image.bp).reshape((self._xi_image.height,self._xi_image.width))
+            img_array = np.asarray(<np.uint8_t[:self._xi_image.bp_size]> self._xi_image.bp).reshape((self._xi_image.height,self._xi_image.width,2))
         elif self._xi_image.frm == xi.XI_RGB24:
             img_array = np.asarray(<np.uint8_t[:self._xi_image.bp_size]> self._xi_image.bp).reshape((self._xi_image.height,self._xi_image.width,3))
         elif self._xi_image.frm == xi.XI_RGB32:


### PR DESCRIPTION
Hello,
I ran into a ValueError (see below) when using the RAW16 format with a xiQ camera. This small changed fix my specific issue. I haven't tested with MONO16. Thanks

```
Traceback (most recent call last):
  File "ximea_camera.py", line 211, in <module>
    main(sys.argv)
  File "ximea_camera.py", line 186, in main
    image, info = c.get_image()
  File "ximea_camera.py", line 111, in get_image
    img, info = self.camera.get_image()
  File "ximea.pyx", line 200, in iph.camera.ximea_camera.ximea.Xi_Camera.get_image (ximea.c:4913)
    img_array = np.asarray(<np.uint16_t[:self._xi_image.bp_size]> self._xi_image.bp).reshape((self._xi_image.height,self._xi_image.width))
ValueError: total size of new array must be unchanged
```
